### PR TITLE
Use default CLI for adding Git aliases in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Adding two git aliases `ack` and `ag` to complement `viack` and `viag` is
 suggested for maximal convenience and the least amount of finger retraining.
 You can do so by running:
 
-    git alias ack "grep-with-smartcase -I --perl-regexp --break --heading --line-number"
-    git alias ag  "grep-with-smartcase -I --perl-regexp --break --heading --line-number"
+    git config --global alias.ack "grep-with-smartcase -I --perl-regexp --break --heading --line-number"
+    git config --global alias.ag  "grep-with-smartcase -I --perl-regexp --break --heading --line-number"
 
 I also like to make the default filename and line number colors match ack's:
 


### PR DESCRIPTION
I think the `git alias` command is only available from things like [git-extras](https://github.com/tj/git-extras) or [hub](https://github.com/github/hub).

Using the original Git CLI would be less confusing to people picking this up.
